### PR TITLE
Fix Sonatype publishing

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -37,7 +37,9 @@ jobs:
       - name: Publish to Maven Central
         run: |
           if [[ $(git tag --points-at HEAD) != '' ]]; then
-            echo "$SONATYPE_PGP_PRIVATE_KEY" | base64 --decode | gpg --import
+            echo $SONATYPE_PGP_PRIVATE_KEY | base64 --decode > gpg_key
+            gpg --import --no-tty --batch --yes gpg_key
+            rm gpg_key
             ./mill -i mill.scalalib.PublishModule/publishAll \
               --sonatypeCreds $SONATYPE_USER:$SONATYPE_PASSWORD \
               --gpgArgs --passphrase=$SONATYPE_PGP_PRIVATE_KEY_PASSWORD,--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b \


### PR DESCRIPTION
With Github actions importing with gpg doesn't work from
stdin. Mill already writes a temporary file. This commit ports
the same mechanism