### PR TITLE
Avoid running tests with `-j $(nproc)`

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -15,7 +15,7 @@ jobs:
         with:
           java-version: 8
       - name: Run tests
-        run: ./mill -i -j $(nproc) __.publishArtifacts __.test
+        run: ./mill -i __.publishArtifacts __.test
 
   publish-sonatype:
     if: github.repository == 'com-lihaoyi/utest' && contains(github.ref, 'refs/tags/')


### PR DESCRIPTION
Trying to download dependencies in parallel is flaky.
This removes the `-j $(nproc)` setting the parallelism level to 1