### PR TITLE
Create release on GitHub when releasing to Maven

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -49,3 +49,13 @@ jobs:
               --release true \
               --signed true
           fi
+      - name: Create GitHub Release
+        id: create_gh_release
+        uses: actions/create-release@v1.1.4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+          body:
+          draft: false


### PR DESCRIPTION
The same setup operates in the Dotty main repo: https://github.com/lampepfl/dotty/blob/master/.github/workflows/ci.yaml#L556. It creates a release on GitHub whenever a release is created via CI.

Besides the motivation to keep the repo in good state, the change also has a motivation of being able to retrieve the latest version of the library via https://github.com/com-lihaoyi/utest/releases/latest.