### PR TITLE
Support concatenation and grouping of `Tests` instances

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1372,6 +1372,12 @@ libraries are currently at.
 Changelog
 =========
 
+0.8.1
+-----
+
+* Add `++` to `Tests` so that test suites can be concatenated
+* Add `.prefix(name: String)` to `Tests` to nest all of its tests under a single test group with a given name
+
 0.8.0
 -----
 

--- a/utest/src/utest/framework/Model.scala
+++ b/utest/src/utest/framework/Model.scala
@@ -21,7 +21,17 @@ object TestPath{
   * executable, which when run either returns a Left(result) or a
   * Right(sequence) of child nodes which you can execute.
   */
-class TestCallTree(inner: => Either[Any, IndexedSeq[TestCallTree]]){
+class TestCallTree(inner: => Either[Any, IndexedSeq[TestCallTree]]) {
+
+  def evalInner() =
+    inner
+
+  def mapInner(f: Either[Any, IndexedSeq[TestCallTree]] => Either[Any, IndexedSeq[TestCallTree]]): TestCallTree =
+    new TestCallTree(f(inner))
+
+  def prefix: TestCallTree =
+    new TestCallTree(Right(IndexedSeq.empty[TestCallTree] :+ this))
+
   /**
    * Runs the test in this [[TestCallTree]] at the specified `path`. Called
    * by the [[TestTreeSeq.run]] method and usually not called manually.

--- a/utest/src/utest/framework/Tree.scala
+++ b/utest/src/utest/framework/Tree.scala
@@ -59,4 +59,7 @@ case class Tree[+T](value: T, children: Tree[T]*){
     else children.toIterator.flatMap(_.leaves)
   }
 
+  def prefix[A >: T](p: A): Tree[A] =
+    Tree(p, this)
+
 }

--- a/utest/test/src/test/utest/MergeTestsTest.scala
+++ b/utest/test/src/test/utest/MergeTestsTest.scala
@@ -1,0 +1,44 @@
+package test.utest
+
+import utest.framework.Tree
+import utest._
+
+abstract class MergeSubTests1 extends TestSuite {
+  var run = Vector.empty[Int]
+  override def tests = Tests {
+    "one" - { run :+= 1 }
+    test("two") { run :+= 2 }
+    "three" - { run :+= 3 }
+  }
+}
+
+abstract class MergeSubTests2 extends TestSuite {
+  var run = Vector.empty[Int]
+  override def tests = Tests {
+    "one" - { run :+= 1 }
+    test("two") { run :+= 2 }
+  }
+}
+
+object MergeTestsTest extends TestSuite {
+
+  val x = new MergeSubTests1 {}
+  val y = new MergeSubTests2 {}
+
+  val local = Tests {
+    "makeSureTestsRan" - {
+      test("x") { assert(x.run == Vector(1, 2, 3) ) }
+      test("y") { assert(y.run == Vector(1, 2) ) }
+    }
+  }
+
+  override def tests =
+    x.tests.prefix("fst") ++
+    y.tests.prefix("snd") ++
+    local
+
+  override def utestAfterAll(): Unit = {
+    assert(x.run == Vector(1, 2, 3))
+    assert(y.run == Vector(1, 2))
+  }
+}


### PR DESCRIPTION
This is useful for creating composable test suites for composable interfaces.

For example, imagine some APIs such as

```scala
trait API1 { /* ... */ }
trait API2 { /* ... */ }
```

Rather than write new tests for every implementation, we can write abstract test suites for the API (similar to laws)

```scala
abstract class Api1Tests extends TestSuite {
  protected def apiTest[A](f: API1 => A): A
  override final def tests = Tests {
    "a" - apiTest { api => /* ... */ }
    "b" - apiTest { api => /* ... */ }
    // etc
  }
}

abstract class Api2Tests extends TestSuite {
  protected def apiTest[A](f: API2 => A): A
  override final def tests = Tests {
    /* ... */
  }
}
```

A problem occurs when a new API is introduced that includes others, such as

```scala
trait API3 {
  val api1: API1
  val api2: API2
}
```

After this PR, it's easy to combine the existing abstract test suites:

```scala
abstract class Api3Tests extends TestSuite { outer =>
  protected def apiTest[A](f: API3 => A): A
  
  private object api1Tests extends Api1Tests {
    override protected def apiTest[A](f: API1 => A): A =
      outer.apiTest(api3 => f(api3.api1))
  }

  private object api2Tests extends Api1Tests {
    override protected def apiTest[A](f: API2 => A): A =
      outer.apiTest(api3 => f(api3.api2))
  }

  override final def tests =
    api1Tests.tests.prefix("api1") ++
    api2Tests.tests.prefix("api2")
}
```
