### PR TITLE
Add Future arrow assert `==*`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -627,6 +627,27 @@ try{
 You can use `a ==> b` as a shorthand for `assert(a == b)`. This results in
 pretty code you can easily copy-paste into documentation.
 
+Test multiple Futures in a for-comprehension:
+
+```scala
+for {
+  _ <- Future(1).map(_ ==> 1)
+  _ <- Future(Array(1, 2, 3)).map(_ ==> Array(1, 2, 3))        
+  _ <- Future(1 ==> 2)
+    .map(_ ==> "Unexpected success")
+    .recover(_.getCause.getMessage ==> "assertion failed: ==> assertion failed: 1 != 2")
+} yield ()
+```
+
+Or use the less verbose `==*` arrow assert for Futures:
+
+```scala
+Future(1) ==* 1
+Future(Array(1, 2, 3)) ==* Array(1, 2, 3)
+(Future(1) ==* 2).recover(_.getCause.getMessage ==> "assertion failed: ==> assertion failed: 1 != 2")
+```
+
+
 Intercept
 ---------
 

--- a/utest/test/src/test/utest/AssertsTests.scala
+++ b/utest/test/src/test/utest/AssertsTests.scala
@@ -1,4 +1,6 @@
 package test.utest
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 import utest._
 import TestUtil.isDotty
 
@@ -130,6 +132,20 @@ object AssertsTests extends utest.TestSuite{
       }catch{case e: java.lang.AssertionError =>
         e
       }
+    }
+    test("arrowAssert with Futures"){
+      for {
+        _ <- Future(1).map(_ ==> 1)
+        _ <- Future(Array(1, 2, 3)).map(_ ==> Array(1, 2, 3))
+        _ <- Future(1 ==> 2)
+          .map(_ ==> "Unexpected success")
+          .recover(_.getCause.getMessage ==> "assertion failed: ==> assertion failed: 1 != 2")
+      } yield ()
+    }
+    test("arrowAssertFuture"){
+      Future(1) ==* 1
+      Future(Array(1, 2, 3)) ==* Array(1, 2, 3)
+      (Future(1) ==* 2).recover(_.getCause.getMessage ==> "assertion failed: ==> assertion failed: 1 != 2")
     }
     test("intercept"){
       test("success"){


### PR DESCRIPTION
Boilerplate code in testing multiple Futures in for-comprehensions can be eliminated with a simple addition of a `==*` arrow assert (or other symbol method) that maps over Futures:

Before:
```scala
for {
  _ <- Future(1).map(_ ==> 1)
  _ <- Future(Array(1, 2, 3)).map(_ ==> Array(1, 2, 3))        
  _ <- Future(1 ==> 2)
    .map(_ ==> "Unexpected success")
    .recover(_.getCause.getMessage ==> "assertion failed: ==> assertion failed: 1 != 2")
} yield ()
```

After:
```scala
Future(1) ==* 1
Future(Array(1, 2, 3)) ==* Array(1, 2, 3)
(Future(1) ==* 2).recover(_.getCause.getMessage ==> "assertion failed: ==> assertion failed: 1 != 2")
```

The `==*` makes the tests more focused on the tested outcome and reduces boilerplate code.