### PR TITLE
Run `Future` tests sequentially, not concurrently

### DIFF
--- a/utest/src-native/utest/PlatformShims.scala
+++ b/utest/src-native/utest/PlatformShims.scala
@@ -2,22 +2,15 @@ package utest
 
 // Taken from the implementation for JS
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
+import concurrent.duration._
 import scala.scalanative.reflect.Reflect
 
 /**
  * Platform specific stuff that differs between JVM, JS and Native
  */
 object PlatformShims {
-  def await[T](f: Future[T]): T = {
-    scala.scalanative.runtime.loop()
-    f.value match {
-      case Some(v) => v.get
-      case None => throw new IllegalStateException(
-        "Test that returns Future must be run asynchronously in Scala Native, see TestTreeSeq::runAsync"
-      )
-    }
-  }
+  def await[T](f: Future[T]): T = Await.result(f, Duration.Inf)
 
   type EnableReflectiveInstantiation =
     scala.scalanative.reflect.annotation.EnableReflectiveInstantiation

--- a/utest/src/utest/TestRunner.scala
+++ b/utest/src/utest/TestRunner.scala
@@ -171,7 +171,9 @@ object TestRunner {
       case HTree.Leaf(f) => f().map(HTree.Leaf(_))
       case HTree.Node(v, children @ _*) =>
         for{
-          childValues <- Future.traverse(children.toSeq)(evaluateFutureTree(_))
+          childValues <- children.foldLeft(Future.successful(List.newBuilder[HTree[N, L]])) { (fb, c) =>
+            fb.flatMap(b => evaluateFutureTree(c).map(b += _))
+          }.map(_.result())
         } yield HTree.Node(v, childValues:_*)
     }
 

--- a/utest/test/src/test/utest/FutureTest.scala
+++ b/utest/test/src/test/utest/FutureTest.scala
@@ -1,0 +1,17 @@
+package test.utest
+import utest._
+import concurrent.{Future, ExecutionContext}
+
+object FutureTest extends TestSuite {
+  implicit val ec: ExecutionContext = ExecutionContext.global
+  @volatile var flag = false
+
+  def tests = TestSuite {
+    test("runs before next test"){
+      Future { flag = true }
+    }
+    test("previous test ran first"){
+      assert(flag)
+    }
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/utest/issues/358.