### PR TITLE
Show failed assertion trace

### DIFF
--- a/utest/src-2/utest/asserts/Tracer.scala
+++ b/utest/src-2/utest/asserts/Tracer.scala
@@ -70,7 +70,8 @@ object Tracer{
     val trees = exprs.map(expr =>
       q"""utest.asserts.AssertEntry(
         ${expr.tree.pos.lineContent.trim},
-        (($loggerName: ${tq""}) => ${tracingTransformer.transform(expr.tree)})
+        (($loggerName: ${tq""}) => ${tracingTransformer.transform(expr.tree)}),
+        ${expr.tree.pos.source.path}+":"+${expr.tree.pos.line},
       )"""
     )
 

--- a/utest/src-3/utest/asserts/Tracer.scala
+++ b/utest/src-3/utest/asserts/Tracer.scala
@@ -99,9 +99,12 @@ object Tracer {
     import quotes.reflect._
     def entryBody(logger: Expr[TestValue => Unit]) =
       tracingMap(logger).transformTerm(expr.asTerm)(Symbol.spliceOwner).asExprOf[T]
+
+    val pos = s"${expr.asTerm.pos.sourceFile}:${expr.asTerm.pos.startLine+1}"
     '{AssertEntry(
       ${Expr(code)},
-      logger => ${entryBody('logger)})}
+      logger => ${entryBody('logger)},
+      ${Expr(pos)})}
 }
 
 object StringUtilHelpers {

--- a/utest/src/utest/asserts/Parallel.scala
+++ b/utest/src/utest/asserts/Parallel.scala
@@ -27,7 +27,7 @@ object Parallel extends ParallelVersionSpecific {
     @tailrec def rec(): Unit = {
       val result = funcs.map(Util.runAssertionEntry)
 
-      val die = result.collectFirst{ case (Failure(_) | Success(false), logged, src) => (logged, src) }
+      val die = result.collectFirst{ case (Failure(_) | Success(false), logged, src, _) => (logged, src) }
       die match{
         case None =>
         case Some((logged, src)) =>
@@ -50,7 +50,7 @@ object Parallel extends ParallelVersionSpecific {
     val start = Deadline.now
     @tailrec def rec(): Unit = {
       val result = funcs.map(Util.runAssertionEntry)
-      val die = result.collectFirst{ case (Failure(_) | Success(false), logged, src) => (logged, src) }
+      val die = result.collectFirst{ case (Failure(_) | Success(false), logged, src, _) => (logged, src) }
       die match{
         case Some((logged, src)) =>
           Util.assertError(

--- a/utest/src/utest/asserts/Util.scala
+++ b/utest/src/utest/asserts/Util.scala
@@ -6,7 +6,7 @@ import utest.{AssertionError, TestValue}
 import scala.collection.mutable.ArrayBuffer
 import scala.util.{Failure, Success, Try}
 
-case class AssertEntry[T](label: String, thunk: (TestValue => Unit) => T)
+case class AssertEntry[T](label: String, thunk: (TestValue => Unit) => T, pos: String)
 /**
   * Created by lihaoyi on 9/9/17.
   */
@@ -32,13 +32,13 @@ object Util {
     * Executes this AssertEntry and returns the raw results
     */
   def runAssertionEntry[T](t: AssertEntry[T]) = {
-    val AssertEntry(src, func) = t
+    val AssertEntry(src, func, pos) = t
     val logged = ArrayBuffer.empty[TestValue]
     val res =
       try Success(func(logged.append(_)))
       catch{case e: Throwable => Failure(e)}
 
-    (res, logged, src)
+    (res, logged, src, pos)
   }
 
 }

--- a/utest/test/src-2.12-jvm/test/utest/FormatterTests.scala
+++ b/utest/test/src-2.12-jvm/test/utest/FormatterTests.scala
@@ -1,4 +1,5 @@
 package test.utest
+import java.io.File
 import utest._
 import concurrent.ExecutionContext.Implicits.global
 
@@ -7,6 +8,10 @@ import concurrent.ExecutionContext.Implicits.global
   * pretty different on Scala.js and Scala-native.
   */
 object FormatterTests extends utest.TestSuite {
+
+  private val testDir: String = new File("").getAbsolutePath
+  private val testFile = s"${testDir.splitAt(testDir.indexOf("out"))._1}utest/test/src-2.12-jvm/test/utest/FormatterTests.scala"
+
   def trim(s: String): String = {
     // Predef.augmentString = work around scala/bug#11125
     Predef.augmentString(s.trim).lines.map(_.reverse.dropWhile(_ == ' ').reverse)
@@ -48,39 +53,41 @@ object FormatterTests extends utest.TestSuite {
       // traces being printed everywhere. Easier to paste it into the test `main`
       // method, running it there, and seeing why it looks wrong
       val expected = trim(
-        """X MyTestSuite.test1
+        s"""X MyTestSuite.test1
           |  java.lang.Exception: wrapper
-          |    test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:)
-          |    test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:)
+          |    test.utest.FormatterTests$$.liftedTree1$$1(FormatterTests.scala:)
+          |    test.utest.FormatterTests$$.$$anonfun$$tests$$3(FormatterTests.scala:)
           |  utest.AssertionError: try assert(x == 2)
+          |  at $testFile:26
           |  x: Int = 1
-          |    utest.asserts.Asserts$.assertImpl(Asserts.scala:)
-          |    test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:)
-          |    test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:)
+          |    utest.asserts.Asserts$$.assertImpl(Asserts.scala:)
+          |    test.utest.FormatterTests$$.liftedTree1$$1(FormatterTests.scala:)
+          |    test.utest.FormatterTests$$.$$anonfun$$tests$$3(FormatterTests.scala:)
           |+ MyTestSuite.test2  1
           |X MyTestSuite.test3
           |  java.lang.IndexOutOfBoundsException: 10
           |    scala.collection.LinearSeqOptimized.apply(LinearSeqOptimized.scala:)
-          |    scala.collection.LinearSeqOptimized.apply$(LinearSeqOptimized.scala:)
+          |    scala.collection.LinearSeqOptimized.apply$$(LinearSeqOptimized.scala:)
           |    scala.collection.immutable.List.apply(List.scala:)
-          |    test.utest.FormatterTests$.$anonfun$tests$6(FormatterTests.scala:)
+          |    test.utest.FormatterTests$$.$$anonfun$$tests$$6(FormatterTests.scala:)
           |- MyTestSuite
           |  X test1
           |    java.lang.Exception: wrapper
-          |      test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:)
-          |      test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:)
+          |      test.utest.FormatterTests$$.liftedTree1$$1(FormatterTests.scala:)
+          |      test.utest.FormatterTests$$.$$anonfun$$tests$$3(FormatterTests.scala:)
           |    utest.AssertionError: try assert(x == 2)
+          |    at $testFile:26
           |    x: Int = 1
-          |      utest.asserts.Asserts$.assertImpl(Asserts.scala:)
-          |      test.utest.FormatterTests$.liftedTree1$1(FormatterTests.scala:)
-          |      test.utest.FormatterTests$.$anonfun$tests$3(FormatterTests.scala:)
+          |      utest.asserts.Asserts$$.assertImpl(Asserts.scala:)
+          |      test.utest.FormatterTests$$.liftedTree1$$1(FormatterTests.scala:)
+          |      test.utest.FormatterTests$$.$$anonfun$$tests$$3(FormatterTests.scala:)
           |  + test2  1
           |  X test3
           |    java.lang.IndexOutOfBoundsException: 10
           |      scala.collection.LinearSeqOptimized.apply(LinearSeqOptimized.scala:)
-          |      scala.collection.LinearSeqOptimized.apply$(LinearSeqOptimized.scala:)
+          |      scala.collection.LinearSeqOptimized.apply$$(LinearSeqOptimized.scala:)
           |      scala.collection.immutable.List.apply(List.scala:)
-          |      test.utest.FormatterTests$.$anonfun$tests$6(FormatterTests.scala:)
+          |      test.utest.FormatterTests$$.$$anonfun$$tests$$6(FormatterTests.scala:)
         """.stripMargin)
 
       assert(trimmedOutput == expected)
@@ -92,6 +99,9 @@ object FormatterTests extends utest.TestSuite {
       val printStream = new java.io.PrintStream(boa)
       val wrappingFormatter = new utest.framework.Formatter{
         override def formatWrapWidth = 50
+      }
+      def wrappedText(indent: Int, text: String): String = {
+        text.grouped(50-indent).mkString("\n" + " " * indent)
       }
       val results = TestRunner.runAndPrint(
         tests,
@@ -106,56 +116,58 @@ object FormatterTests extends utest.TestSuite {
       // traces being printed everywhere. Easier to paste it into the test `main`
       // method, running it there, and seeing why it looks wrong
       val expected = trim(
-        """X MyTestSuite.test1
+        s"""X MyTestSuite.test1
           |  java.lang.Exception: wrapper
-          |    test.utest.FormatterTests$.liftedTree1$1(Forma
+          |    test.utest.FormatterTests$$.liftedTree1$$1(Forma
           |    tterTests.scala:)
-          |    test.utest.FormatterTests$.$anonfun$tests$3(Fo
+          |    test.utest.FormatterTests$$.$$anonfun$$tests$$3(Fo
           |    rmatterTests.scala:)
           |  utest.AssertionError: try assert(x == 2)
+          |  ${wrappedText(2, s"at $testFile:26")}
           |  x: Int = 1
-          |    utest.asserts.Asserts$.assertImpl(Asserts.scal
+          |    utest.asserts.Asserts$$.assertImpl(Asserts.scal
           |    a:)
-          |    test.utest.FormatterTests$.liftedTree1$1(Forma
+          |    test.utest.FormatterTests$$.liftedTree1$$1(Forma
           |    tterTests.scala:)
-          |    test.utest.FormatterTests$.$anonfun$tests$3(Fo
+          |    test.utest.FormatterTests$$.$$anonfun$$tests$$3(Fo
           |    rmatterTests.scala:)
           |+ MyTestSuite.test2  1
           |X MyTestSuite.test3
           |  java.lang.IndexOutOfBoundsException: 10
           |    scala.collection.LinearSeqOptimized.apply(Line
           |    arSeqOptimized.scala:)
-          |    scala.collection.LinearSeqOptimized.apply$(Lin
+          |    scala.collection.LinearSeqOptimized.apply$$(Lin
           |    earSeqOptimized.scala:)
           |    scala.collection.immutable.List.apply(List.sca
           |    la:)
-          |    test.utest.FormatterTests$.$anonfun$tests$6(Fo
+          |    test.utest.FormatterTests$$.$$anonfun$$tests$$6(Fo
           |    rmatterTests.scala:)
           |- MyTestSuite
           |  X test1
           |    java.lang.Exception: wrapper
-          |      test.utest.FormatterTests$.liftedTree1$1(For
+          |      test.utest.FormatterTests$$.liftedTree1$$1(For
           |      matterTests.scala:)
-          |      test.utest.FormatterTests$.$anonfun$tests$3(
+          |      test.utest.FormatterTests$$.$$anonfun$$tests$$3(
           |      FormatterTests.scala:)
           |    utest.AssertionError: try assert(x == 2)
+          |    ${wrappedText(4, s"at $testFile:26")}
           |    x: Int = 1
-          |      utest.asserts.Asserts$.assertImpl(Asserts.sc
+          |      utest.asserts.Asserts$$.assertImpl(Asserts.sc
           |      ala:)
-          |      test.utest.FormatterTests$.liftedTree1$1(For
+          |      test.utest.FormatterTests$$.liftedTree1$$1(For
           |      matterTests.scala:)
-          |      test.utest.FormatterTests$.$anonfun$tests$3(
+          |      test.utest.FormatterTests$$.$$anonfun$$tests$$3(
           |      FormatterTests.scala:)
           |  + test2  1
           |  X test3
           |    java.lang.IndexOutOfBoundsException: 10
           |      scala.collection.LinearSeqOptimized.apply(Li
           |      nearSeqOptimized.scala:)
-          |      scala.collection.LinearSeqOptimized.apply$(L
+          |      scala.collection.LinearSeqOptimized.apply$$(L
           |      inearSeqOptimized.scala:)
           |      scala.collection.immutable.List.apply(List.s
           |      cala:)
-          |      test.utest.FormatterTests$.$anonfun$tests$6(
+          |      test.utest.FormatterTests$$.$$anonfun$$tests$$6(
           |      FormatterTests.scala:)
         """.stripMargin)
 


### PR DESCRIPTION
/claim https://github.com/com-lihaoyi/utest/issues/354

Because the tests are macro-expansion from both `Tests.apply` and `assertImpl` so the original assertion position is lost after `Tracer.apply` converts test expressions into `Expr[Unit]`

https://github.com/com-lihaoyi/utest/blob/76e7fe5a72464ab44df3f829bd2b3e7699d522bf/utest/src-3/utest/asserts/Tracer.scala#L24

This PR is an attempt to preserve original assertion's position by introducing `pos: String` field in `AssertEntry`, which is formatted as `${sourceFile}:${line}` so that we can output failed assertion location under `AssertionError` like:

```bash
X test.utest.examples.HelloTests.test4 2ms
[113]   utest.AssertionError:  1 == 2
[113]   at .../utest/utest/test/src/test/utest/examples/HelloTests.scala:21
[113]     utest.asserts.Asserts$.assertImpl(Asserts.scala:31)
[113]     test.utest.examples.HelloTests$.$init$$$anonfun$1$$anonfun$4(HelloTests.scala:5)
```