### PR TITLE
fix linenumbers in failed assertion traces

### DIFF
--- a/utest/test/src-jvm/test/utest/LineNumbersTests.scala
+++ b/utest/test/src-jvm/test/utest/LineNumbersTests.scala
@@ -1,0 +1,57 @@
+package test.utest
+
+import utest._
+import utest.framework.{TestCallTree, Tree}
+
+object LineNumbersTests extends utest.TestSuite {
+
+  val testsToRun = Tests {
+    test("test1") {
+      val x = 1
+      assert(x == 2)
+    }
+    test("test2") {
+      assert(1 == 2)
+    }
+    test("test3") {
+      test("innerTest3")(assert(1 == 2))
+    }
+    test("test4") {
+      test("innerTest4") {
+        assert(1 == 2)
+      }
+    }
+
+    test("test5") {
+      test("innerTest5") {
+        println("extra statement")
+        assert(1 == 2)
+      }
+    }
+  }
+
+  val testBody = {
+
+    val results = TestRunner.run(
+      testsToRun
+    )
+
+    val stackTraceLinesFromThisFile = results.mapLeaves(_.value.failed.get.getStackTrace.toList.filter(_.getFileName == "LineNumbersTests.scala").toList).leaves.toList
+
+    assert(
+      stackTraceLinesFromThisFile(0).exists(_.getLineNumber == 11),
+      stackTraceLinesFromThisFile(1).exists(_.getLineNumber == 14),
+      stackTraceLinesFromThisFile(2).exists(_.getLineNumber == 17),
+      stackTraceLinesFromThisFile(3).exists(_.getLineNumber == 21),
+      stackTraceLinesFromThisFile(4).exists(_.getLineNumber == 28),
+
+    )
+
+  }
+
+  val tests = Tests(Tree(""), new TestCallTree(Left(testBody))) //don't use Tests macro for stability
+
+}
+
+
+


### PR DESCRIPTION
There are two places that break line numbering:

**1. Tracer. apply - betaReduce**
compiler implementation of BetaReduce tries to convert Inlined terms using inlineContext - which seems to break positions
There are 2 ways to fix:
a - do not call betaReduce at all
b - transform Inlined with current Quotes context
I have chosen b - because it does a lesser logic change compared to b.
My implementation is equivalent to what Term.betaReduce does, with one difference that original Term.betaReduce computes inlineContext instead of directly using Quotes.

**2. TestBuilder.testCallTreeExpr**
Despite `assert` expression does have proper position attached to it, compiler for some reasons doesn't use it in generation of lineNumbersTable in class files.
Wrapping it into `Inlined` term fixes it.

Honestly, I didn't dig into compiler internals to figure out how exactly it treats `Inlined` when generating LineNumberTable.
However have seen lots of places where `Inlined` terms get some special treatment when it comes to spans (which are responsible for linenumbers and positions).

**Worth to mention:**
- **Term.pos** is not always equivalent to final line number in the classfiles LineNumberTable.
- general rule of thumb is that expressions present in source code should get linenumber from sourcecode and expressions generated by macro should get linenumber of where macro is expanded.
If we use only `assert` macro then **fix 1** is enough, however when we use both `Test` and `assert` inside it - which is normal usecase of utest, then two fixes are needed.
- We cannot change Tree position directly, there is no public api exposed for this. We can try to use `Inlined.copy` or `Inlined.apply` to have some influence on linenumbers, but its limited.
- `changeOwner` doesnt affect linennumber