### PR TITLE
Rename `intercept` to `assertThrows`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -52,7 +52,7 @@ Contents
   - [Asynchronous Tests](#asynchronous-tests)
 - [Smart Asserts](#smart-asserts)
   - [Arrow Asserts](#arrow-asserts)
-  - [Intercept](#intercept)
+  - [assertThrows](#assertThrows)
   - [Eventually and Continually](#eventually-and-continually)
   - [Assert Match](#assert-match)
   - [Compile Error](#compile-error)
@@ -632,11 +632,11 @@ try{
 You can use `a ==> b` as a shorthand for `assert(a == b)`. This results in
 pretty code you can easily copy-paste into documentation.
 
-Intercept
+assertThrows
 ---------
 
 ```scala
-val e = intercept[MatchError]{
+val e = assertThrows[MatchError]{
   (0: Any) match { case _: String => }
 }
 println(e)
@@ -644,13 +644,13 @@ println(e)
 // scala.MatchError: 0 (of class java.lang.Integer)
 ```
 
-`intercept` allows you to verify that a block raises an exception. This
+`assertThrows` allows you to verify that a block raises an exception. This
 exception is caught and returned so you can perform further validation on it,
 e.g. checking that the message is what you expect. If the block does not raise
 one, an `AssertionError` is raised.
 
-As with `assert`, `intercept` adds debugging information to the error messages
-if the `intercept` fails or throws an unexpected Exception.
+As with `assert`, `assertThrows` adds debugging information to the error messages
+if the `assertThrows` fails or throws an unexpected Exception.
 
 Eventually and Continually
 --------------------------
@@ -730,7 +730,7 @@ compileError("(}")
   `CompileError.Parse(pos: String, msgs: String*)` to represent typechecker
   errors or parser errors
 
-In general, `compileError` works similarly to `intercept`, except it does its
+In general, `compileError` works similarly to `assertThrows`, except it does its
 checks (that a snippet of code fails) and errors (if it doesn't fail) at
 compile-time rather than run-time. If the code fails as expected, the failure
 message is propagated to runtime in the form of a `CompileError` object. You can

--- a/utest/src-2/utest/asserts/Asserts.scala
+++ b/utest/src-2/utest/asserts/Asserts.scala
@@ -99,14 +99,14 @@ trait AssertsCompanionVersionSpecific {
     Tracer[Boolean](c)(q"utest.asserts.Asserts.assertImpl", exprs:_*)
   }
 
-  def interceptProxy[T: c.WeakTypeTag]
+  def assertThrowsProxy[T: c.WeakTypeTag]
                     (c: Context)
                     (exprs: c.Expr[Unit])
                     (t: c.Expr[ClassTag[T]]): c.Expr[T] = {
     import c.universe._
     val typeTree = implicitly[c.WeakTypeTag[T]]
 
-    val x = Tracer[Unit](c)(q"utest.asserts.Asserts.interceptImpl[$typeTree]", exprs)
+    val x = Tracer[Unit](c)(q"utest.asserts.Asserts.assertThrowsImpl[$typeTree]", exprs)
     c.Expr[T](q"$x($t)")
   }
 
@@ -155,6 +155,6 @@ trait AssertsVersionSpecific {
     * is returned if raised, and an `AssertionError` is raised if the expected
     * exception does not appear.
     */
-  def intercept[T: ClassTag](exprs: Unit): T = macro Asserts.interceptProxy[T]
+  def assertThrows[T: ClassTag](exprs: Unit): T = macro Asserts.assertThrowsProxy[T]
 }
 

--- a/utest/src-3/utest/asserts/Asserts.scala
+++ b/utest/src-3/utest/asserts/Asserts.scala
@@ -25,11 +25,11 @@ trait AssertsCompanionVersionSpecific {
     Tracer.traceOneWithCode[Any, Unit]('{ (x: AssertEntry[Any]) => utest.asserts.Asserts.assertMatchImpl(x)($pf) }, t, code)
   }
 
-  def interceptProxy[T](exprs: Expr[Unit])(using Quotes, Type[T]): Expr[T] = {
+  def assertThrowsProxy[T](exprs: Expr[Unit])(using Quotes, Type[T]): Expr[T] = {
     import quotes.reflect._
     val clazz = Literal(ClassOfConstant(TypeRepr.of[T]))
     Tracer.traceOne[Unit, T]('{ (x: AssertEntry[Unit]) =>
-      utest.asserts.Asserts.interceptImpl[T](x)(ClassTag(${clazz.asExprOf[Class[T]]})) }, exprs)
+      utest.asserts.Asserts.assertThrowsImpl[T](x)(ClassTag(${clazz.asExprOf[Class[T]]})) }, exprs)
   }
 
   def compileErrorImpl(errors: List[Error], snippet: String): CompileError =
@@ -82,6 +82,6 @@ trait AssertsVersionSpecific {
     * is returned if raised, and an `AssertionError` is raised if the expected
     * exception does not appear.
     */
-  inline def intercept[T](inline exprs: Unit): T = ${Asserts.interceptProxy[T]('exprs)}
+  inline def assertThrows[T](inline exprs: Unit): T = ${Asserts.assertThrowsProxy[T]('exprs)}
 }
 

--- a/utest/src/utest/asserts/Asserts.scala
+++ b/utest/src/utest/asserts/Asserts.scala
@@ -41,7 +41,7 @@ object Asserts extends AssertsCompanionVersionSpecific {
    * is returned if raised, and an `AssertionError` is raised if the expected
    * exception does not appear.
    */
-  def interceptImpl[T: ClassTag](entry: AssertEntry[Unit]): T = {
+  def assertThrowsImpl[T: ClassTag](entry: AssertEntry[Unit]): T = {
     val (res, logged, src) = Util.runAssertionEntry(entry)
     res match{
       case Failure(e: T) => e

--- a/utest/test/src-jvm/test/utest/Parallel.scala
+++ b/utest/test/src-jvm/test/utest/Parallel.scala
@@ -54,7 +54,7 @@ object Parallel extends TestSuite{
       "failure"-{
         val x = Seq(12)
         val y = 1
-        val error = intercept[AssertionError]{
+        val error = assertThrows[AssertionError]{
           eventually(
             x == Nil,
             y == 1
@@ -96,7 +96,7 @@ object Parallel extends TestSuite{
 
         val i = Counter()
 
-        intercept[AssertionError]{
+        assertThrows[AssertionError]{
           eventually{
             i() > 5
           }
@@ -109,7 +109,7 @@ object Parallel extends TestSuite{
 
         val i = Counter()
 
-        intercept[AssertionError]{
+        assertThrows[AssertionError]{
           eventually{
             i() > 5
           }
@@ -121,7 +121,7 @@ object Parallel extends TestSuite{
       "failure"-{
 
         val i = Counter()
-        val error = intercept[AssertionError]{
+        val error = assertThrows[AssertionError]{
           continually(
             i() < 4
           )

--- a/utest/test/src/test/utest/AssertsTests.scala
+++ b/utest/test/src/test/utest/AssertsTests.scala
@@ -258,9 +258,9 @@ object AssertsTests extends utest.TestSuite{
         e
       }
     }
-    test("intercept"){
+    test("assertThrows"){
       test("success"){
-        val e = intercept[MatchError]{
+        val e = assertThrows[MatchError]{
           (0: Any) match { case _: String => }
         }
         Predef.assert(e.toString.contains("MatchError"))
@@ -270,7 +270,7 @@ object AssertsTests extends utest.TestSuite{
         try {
           val x = 1
           val y = 2.0
-          intercept[NumberFormatException]{
+          assertThrows[NumberFormatException]{
             (x: Any) match { case _: String => y + 1 }
           }
           Predef.assert(false) // error wasn't thrown???
@@ -288,7 +288,7 @@ object AssertsTests extends utest.TestSuite{
         try{
           val x = 1
           val y = 2.0
-          intercept[NullPointerException]{
+          assertThrows[NullPointerException]{
             123 + x + y
           }
         }catch {case e: utest.AssertionError =>
@@ -297,9 +297,9 @@ object AssertsTests extends utest.TestSuite{
           e.getMessage
         }
       }
-      test("interceptWithAssignment"){
+      test("assertThrowsWithAssignment"){
         var W = 1
-        try utest.intercept[Exception] { W = 2 }
+        try utest.assertThrows[Exception] { W = 2 }
         catch{case e: utest.AssertionError => e.getMessage}
       }
     }


### PR DESCRIPTION
This makes it fit better into the rest of the library's `assert`, `assertMatches`, etc.