### PR TITLE
Rename variadic `assert` to `assertAll`, add `assert` variant with explicit message

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -577,14 +577,17 @@ Smart Asserts
 ```scala
 val x = 1
 val y = "2"
-assert(
-  x > 0,
-  x == y
-)
+assert(x > 0)
+assert(x == y)
 
 // utest.AssertionError: x == y
 // x: Int = 1
 // y: String = 2
+
+assertAll( // Helper to perform multiple asserts at once
+  x > 0,
+  x == y
+)
 ```
 
 uTest comes with a macro-powered smart `assert`s that provide useful debugging

--- a/utest/src-2/utest/asserts/Asserts.scala
+++ b/utest/src-2/utest/asserts/Asserts.scala
@@ -132,6 +132,13 @@ trait AssertsVersionSpecific {
     * exception with some debugging info
     */
   def assert(exprs: Boolean*): Unit = macro Asserts.assertProxy
+
+  /**
+   * Forwarder for `Predef.assert`, for when you want to explicitly write the
+   * assert message and don't want or need the fancy smart asserts
+   */
+  def assert(expr: Boolean, msg: => Any) = Predef.assert(expr, msg)
+
   /**
     * Checks that one or more expressions all become true within a certain
     * period of time. Polls at a regular interval to check this.

--- a/utest/src-2/utest/asserts/Asserts.scala
+++ b/utest/src-2/utest/asserts/Asserts.scala
@@ -94,19 +94,25 @@ trait AssertsCompanionVersionSpecific {
     }
   }
 
-  def assertProxy(c: Context)(exprs: c.Expr[Boolean]*): c.Expr[Unit] = {
+  def assertProxy(c: Context)(expr: c.Expr[Boolean]): c.Expr[Unit] = {
     import c.universe._
-    Tracer[Boolean](c)(q"utest.asserts.Asserts.assertImpl", exprs:_*)
+    Tracer[Boolean](c)(q"utest.asserts.Asserts.assertImpl", expr)
+  }
+
+
+  def assertAllProxy(c: Context)(expr: c.Expr[Boolean]*): c.Expr[Unit] = {
+    import c.universe._
+    Tracer[Boolean](c)(q"utest.asserts.Asserts.assertImpl", expr:_*)
   }
 
   def assertThrowsProxy[T: c.WeakTypeTag]
                     (c: Context)
-                    (exprs: c.Expr[Unit])
+                    (expr: c.Expr[Unit])
                     (t: c.Expr[ClassTag[T]]): c.Expr[T] = {
     import c.universe._
     val typeTree = implicitly[c.WeakTypeTag[T]]
 
-    val x = Tracer[Unit](c)(q"utest.asserts.Asserts.assertThrowsImpl[$typeTree]", exprs)
+    val x = Tracer[Unit](c)(q"utest.asserts.Asserts.assertThrowsImpl[$typeTree]", expr)
     c.Expr[T](q"$x($t)")
   }
 
@@ -127,11 +133,6 @@ trait AssertsVersionSpecific {
     * compile successfully, this macro itself will raise a compilation error.
     */
   def compileError(expr: String): CompileError = macro Asserts.compileError
-  /**
-    * Checks that one or more expressions are true; otherwises raises an
-    * exception with some debugging info
-    */
-  def assert(exprs: Boolean*): Unit = macro Asserts.assertProxy
 
   /**
    * Forwarder for `Predef.assert`, for when you want to explicitly write the
@@ -140,15 +141,26 @@ trait AssertsVersionSpecific {
   def assert(expr: Boolean, msg: => Any) = Predef.assert(expr, msg)
 
   /**
+   * Checks that the expression is true; otherwise raises an
+   * exception with some debugging info
+   */
+  def assert(expr: Boolean): Unit = macro Asserts.assertProxy
+
+  /**
+    * Checks that one or more expressions are true; otherwise raises an
+    * exception with some debugging info
+    */
+  def assertAll(expr: Boolean*): Unit = macro Asserts.assertAllProxy
+  /**
     * Checks that one or more expressions all become true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  def eventually(exprs: Boolean*): Unit = macro Parallel.eventuallyProxy
+  def eventually(expr: Boolean): Unit = macro Parallel.eventuallyProxy
   /**
     * Checks that one or more expressions all remain true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  def continually(exprs: Boolean*): Unit = macro Parallel.continuallyProxy
+  def continually(expr: Boolean): Unit = macro Parallel.continuallyProxy
 
   /**
     * Asserts that the given value matches the PartialFunction. Useful for using
@@ -162,6 +174,6 @@ trait AssertsVersionSpecific {
     * is returned if raised, and an `AssertionError` is raised if the expected
     * exception does not appear.
     */
-  def assertThrows[T: ClassTag](exprs: Unit): T = macro Asserts.assertThrowsProxy[T]
+  def assertThrows[T: ClassTag](expr: Unit): T = macro Asserts.assertThrowsProxy[T]
 }
 

--- a/utest/src-2/utest/asserts/Parallel.scala
+++ b/utest/src-2/utest/asserts/Parallel.scala
@@ -12,14 +12,14 @@ import scala.util.{Failure, Success, Try}
  */
 trait ParallelVersionSpecific {
 
-  def eventuallyProxy(c: Context)(exprs: c.Expr[Boolean]*): c.Expr[Unit] = {
+  def eventuallyProxy(c: Context)(expr: c.Expr[Boolean]): c.Expr[Unit] = {
     import c.universe._
-    Tracer[Boolean](c)(q"utest.asserts.Parallel.eventuallyImpl", exprs:_*)
+    Tracer[Boolean](c)(q"utest.asserts.Parallel.eventuallyImpl", expr)
   }
 
-  def continuallyProxy(c: Context)(exprs: c.Expr[Boolean]*): c.Expr[Unit] = {
+  def continuallyProxy(c: Context)(expr: c.Expr[Boolean]): c.Expr[Unit] = {
     import c.universe._
-    Tracer[Boolean](c)(q"utest.asserts.Parallel.continuallyImpl", exprs:_*)
+    Tracer[Boolean](c)(q"utest.asserts.Parallel.continuallyImpl", expr)
   }
 }
 

--- a/utest/src-3/utest/TestBuilder.scala
+++ b/utest/src-3/utest/TestBuilder.scala
@@ -31,7 +31,8 @@ object TestBuilder:
     val assertInliner = new TreeMap {
       override def transformTerm(term: Term)(owner: Symbol): Term = scala.util.Try(term.asExpr) match {
           case Success(expr) => expr match
-            case '{utest.assert(${_}*) } => Inlined(None,Nil,term) //Inlined results in proper line number generation
+            case '{utest.assert(${_}) } => Inlined(None,Nil,term) //Inlined results in proper line number generation
+            case '{utest.assertAll(${_}*) } => Inlined(None,Nil,term) //Inlined results in proper line number generation
             case _ => super.transformTerm(term)(owner)
           case _ => super.transformTerm(term)(owner)
       }

--- a/utest/src-3/utest/asserts/Asserts.scala
+++ b/utest/src-3/utest/asserts/Asserts.scala
@@ -59,6 +59,12 @@ trait AssertsVersionSpecific {
   inline def assert(inline exprs: Boolean*): Unit = ${Asserts.assertProxy('exprs)}
 
   /**
+   * Forwarder for `Predef.assert`, for when you want to explicitly write the
+   * assert message and don't want or need the fancy smart asserts
+   */
+  def assert(expr: Boolean, msg: => Any) = Predef.assert(expr, msg)
+
+  /**
     * Checks that one or more expressions all become true within a certain
     * period of time. Polls at a regular interval to check this.
     */

--- a/utest/src-3/utest/asserts/Asserts.scala
+++ b/utest/src-3/utest/asserts/Asserts.scala
@@ -15,8 +15,14 @@ import scala.collection.mutable
  * message for boolean expression assertion.
  */
 trait AssertsCompanionVersionSpecific {
-  def assertProxy(exprs: Expr[Seq[Boolean]])(using ctx: Quotes): Expr[Unit] = {
+  def assertProxy(expr: Expr[Boolean])(using ctx: Quotes): Expr[Unit] = {
+    Tracer.single[Boolean](
+      '{ (esx: Seq[AssertEntry[Boolean]]) => utest.asserts.Asserts.assertImpl(esx: _*) },
+      expr
+    )
+  }
 
+  def assertAllProxy(exprs: Expr[Seq[Boolean]])(using ctx: Quotes): Expr[Unit] = {
     Tracer[Boolean] ('{ (esx: Seq[AssertEntry[Boolean]]) => utest.asserts.Asserts.assertImpl(esx: _*) }, exprs)
   }
 
@@ -25,11 +31,11 @@ trait AssertsCompanionVersionSpecific {
     Tracer.traceOneWithCode[Any, Unit]('{ (x: AssertEntry[Any]) => utest.asserts.Asserts.assertMatchImpl(x)($pf) }, t, code)
   }
 
-  def assertThrowsProxy[T](exprs: Expr[Unit])(using Quotes, Type[T]): Expr[T] = {
+  def assertThrowsProxy[T](expr: Expr[Unit])(using Quotes, Type[T]): Expr[T] = {
     import quotes.reflect._
     val clazz = Literal(ClassOfConstant(TypeRepr.of[T]))
     Tracer.traceOne[Unit, T]('{ (x: AssertEntry[Unit]) =>
-      utest.asserts.Asserts.assertThrowsImpl[T](x)(ClassTag(${clazz.asExprOf[Class[T]]})) }, exprs)
+      utest.asserts.Asserts.assertThrowsImpl[T](x)(ClassTag(${clazz.asExprOf[Class[T]]})) }, expr)
   }
 
   def compileErrorImpl(errors: List[Error], snippet: String): CompileError =
@@ -53,10 +59,16 @@ trait AssertsVersionSpecific {
   transparent inline def compileError(inline expr: String): CompileError = compileErrorImpl(typeCheckErrors(expr), expr)
 
   /**
-    * Checks that one or more expressions are true; otherwises raises an
+   * Checks that the expression is true; otherwise raises an
+   * exception with some debugging info
+   */
+  inline def assert(inline expr: Boolean): Unit = ${Asserts.assertProxy('expr)}
+
+  /**
+    * Checks that one or more expressions are true; otherwise raises an
     * exception with some debugging info
     */
-  inline def assert(inline exprs: Boolean*): Unit = ${Asserts.assertProxy('exprs)}
+  inline def assertAll(inline expr: Boolean*): Unit = ${Asserts.assertAllProxy('expr)}
 
   /**
    * Forwarder for `Predef.assert`, for when you want to explicitly write the
@@ -68,14 +80,14 @@ trait AssertsVersionSpecific {
     * Checks that one or more expressions all become true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  inline def eventually(inline exprs: Boolean*)(using ri: => RetryInterval, rm: => RetryMax): Unit =
-    ${Parallel.eventuallyProxy('exprs, 'ri, 'rm)}
+  inline def eventually(inline expr: Boolean)(using ri: => RetryInterval, rm: => RetryMax): Unit =
+    ${Parallel.eventuallyProxy('expr, 'ri, 'rm)}
   /**
     * Checks that one or more expressions all remain true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  inline def continually(inline exprs: Boolean*)(using ri: => RetryInterval, rm: => RetryMax): Unit =
-    ${Parallel.continuallyProxy('exprs, 'ri, 'rm)}
+  inline def continually(inline expr: Boolean)(using ri: => RetryInterval, rm: => RetryMax): Unit =
+    ${Parallel.continuallyProxy('expr, 'ri, 'rm)}
 
   /**
     * Asserts that the given value matches the PartialFunction. Useful for using
@@ -88,6 +100,6 @@ trait AssertsVersionSpecific {
     * is returned if raised, and an `AssertionError` is raised if the expected
     * exception does not appear.
     */
-  inline def assertThrows[T](inline exprs: Unit): T = ${Asserts.assertThrowsProxy[T]('exprs)}
+  inline def assertThrows[T](inline expr: Unit): T = ${Asserts.assertThrowsProxy[T]('expr)}
 }
 

--- a/utest/src-3/utest/asserts/Parallel.scala
+++ b/utest/src-3/utest/asserts/Parallel.scala
@@ -12,10 +12,10 @@ import scala.util.{Failure, Success, Try}
  */
 trait ParallelVersionSpecific {
 
-  def eventuallyProxy(exprs: Expr[Seq[Boolean]], ri: Expr[RetryInterval], rm: Expr[RetryMax])(using ctx: Quotes): Expr[Unit] =
-    Tracer[Boolean]('{ (esx: Seq[AssertEntry[Boolean]]) => utest.asserts.Parallel.eventuallyImpl(esx: _*)(using $ri, $rm) }, exprs)
+  def eventuallyProxy(expr: Expr[Boolean], ri: Expr[RetryInterval], rm: Expr[RetryMax])(using ctx: Quotes): Expr[Unit] =
+    Tracer.single[Boolean]('{ (esx: Seq[AssertEntry[Boolean]]) => utest.asserts.Parallel.eventuallyImpl(esx: _*)(using $ri, $rm) }, expr)
 
-  def continuallyProxy(exprs: Expr[Seq[Boolean]], ri: Expr[RetryInterval], rm: Expr[RetryMax])(using ctx: Quotes): Expr[Unit] =
-    Tracer[Boolean]('{ (esx: Seq[AssertEntry[Boolean]]) => utest.asserts.Parallel.continuallyImpl(esx: _*)(using $ri, $rm) }, exprs)
+  def continuallyProxy(expr: Expr[Boolean], ri: Expr[RetryInterval], rm: Expr[RetryMax])(using ctx: Quotes): Expr[Unit] =
+    Tracer.single[Boolean]('{ (esx: Seq[AssertEntry[Boolean]]) => utest.asserts.Parallel.continuallyImpl(esx: _*)(using $ri, $rm) }, expr)
 
 }

--- a/utest/src-3/utest/asserts/Tracer.scala
+++ b/utest/src-3/utest/asserts/Tracer.scala
@@ -42,6 +42,13 @@ object Tracer {
       case _ => throw new RuntimeException(s"Only varargs are supported. Got: ${exprs.asTerm}")
     }
   }
+  def single[T](func: Expr[Seq[AssertEntry[T]] => Unit], expr: Expr[T])(using Quotes, Type[T]): Expr[Unit] = {
+    import quotes.reflect.*
+
+    val trees: Expr[Seq[AssertEntry[T]]] = Expr.ofSeq(Seq(expr).map(e => makeAssertEntry(e, codeOf(e))))
+    betaReduceKeepLineNumbers('{ $func($trees)}.asTerm).asExprOf[Unit]
+
+  }
 
   def codeOf[T](expr: Expr[T])(using Quotes): String =
     import quotes.reflect._

--- a/utest/test/src-jvm/test/utest/LineNumbersTests.scala
+++ b/utest/test/src-jvm/test/utest/LineNumbersTests.scala
@@ -91,14 +91,14 @@ object LineNumbersTests extends utest.TestSuite {
 
 
         var header = "header"
-        assert(
+        assertAll(
           1 == 1,
           header == "//GPL"
         )
 
         println("")
 
-        assert(
+        assertAll(
           1 == 2,
           header == "//MIT "
         )
@@ -106,7 +106,7 @@ object LineNumbersTests extends utest.TestSuite {
     }
     test("test14") {
       val result = "testing".trim()
-      assert(
+      assertAll(
         result == "notMatching",
         1 == 2)
       result
@@ -125,7 +125,7 @@ object LineNumbersTests extends utest.TestSuite {
 
     val stackTraceLinesFromThisFile = results.mapLeaves(_.value.failed.get.getStackTrace.toList.filter(_.getFileName == "LineNumbersTests.scala").toList).leaves.toList
 
-    assert(
+    assertAll(
       stackTraceLinesFromThisFile(0).exists(_.getLineNumber == 11),
       stackTraceLinesFromThisFile(1).exists(_.getLineNumber == 14),
       stackTraceLinesFromThisFile(2).exists(_.getLineNumber == 17),

--- a/utest/test/src-jvm/test/utest/Parallel.scala
+++ b/utest/test/src-jvm/test/utest/Parallel.scala
@@ -55,10 +55,7 @@ object Parallel extends TestSuite{
         val x = Seq(12)
         val y = 1
         val error = assertThrows[AssertionError]{
-          eventually(
-            x == Nil,
-            y == 1
-          )
+          eventually(x == Nil && y == 1)
         }
 
         val expected = Seq(
@@ -136,10 +133,7 @@ object Parallel extends TestSuite{
         val x = Seq(12)
         val y = 1
 
-        continually(
-          x == Seq(12),
-          y == 1
-        )
+        continually(x == Seq(12) && y == 1)
       }
     }
   }

--- a/utest/test/src/test/utest/AssertsTests.scala
+++ b/utest/test/src/test/utest/AssertsTests.scala
@@ -22,7 +22,7 @@ object AssertsTests extends utest.TestSuite{
         val (e, logged, cause) = try {
           val x = 1
           val y = "2"
-          assert(
+          assertAll(
             x > 0,
             x.toString == y
           )
@@ -213,7 +213,7 @@ object AssertsTests extends utest.TestSuite{
       test("multiple"){
         def die = throw new IllegalArgumentException("foo")
         val msg1 = try {
-          assert(
+          assertAll(
             1 == 2,
             die
           )
@@ -223,7 +223,7 @@ object AssertsTests extends utest.TestSuite{
         }
         Predef.assert(msg1.contains("#1: 1 == 2"))
         val msg2 = try {
-          assert(
+          assertAll(
             1 == 1,
             die
           )

--- a/utest/test/src/test/utest/BeforeAfterAllFailureTest.scala
+++ b/utest/test/src/test/utest/BeforeAfterAllFailureTest.scala
@@ -48,7 +48,7 @@ object BeforeAfterAllFailureTest extends TestSuite {
         .toList
       val successes = res.leaves.count(_.value.isSuccess)
       val filteredStackLengths = failures.map(x => StackMarker.filterCallStack(x.getStackTrace).length)
-      assert(
+      assertAll(
         successes == 0,
         failures.map(_.getMessage) == Seq("Failed After!"),
         // Make sure we return stack traces that get truncated to reasonably

--- a/utest/test/src/test/utest/FrameworkTests.scala
+++ b/utest/test/src/test/utest/FrameworkTests.scala
@@ -172,7 +172,7 @@ object FrameworkTests extends utest.TestSuite{
             test("inner"){
               val z = y + 1
               test("innerest"){
-                assert(
+                assertAll(
                   x == 1,
                   y == 2,
                   z == 3

--- a/utest/test/src/test/utest/Main.scala
+++ b/utest/test/src/test/utest/Main.scala
@@ -14,7 +14,7 @@ object Main {
           val b = 2
           val c = 3
           val d = 4
-          assert(
+          assertAll(
             a == 1,
             c == d,
             ???

--- a/utest/test/src/test/utest/examples/NestedTests.scala
+++ b/utest/test/src/test/utest/examples/NestedTests.scala
@@ -10,7 +10,7 @@ object NestedTests extends TestSuite{
       val y = x + 1
 
       test("inner1"){
-        assert(x == 1, y == 2)
+        assertAll(x == 1, y == 2)
         (x, y)
       }
       test("inner2"){


### PR DESCRIPTION
This should help avoid a common point of friction for newbies using the library