### PR TITLE
Prefix `compileError`/`eventually`/`continually` with `assert`

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -11,7 +11,7 @@ import com.github.lolgab.mill.mima._
 
 val communityBuildDottyVersion = sys.props.get("dottyVersion").toList
 
-val scalaVersions = "2.12.20" :: "2.13.14" :: "3.3.3" :: communityBuildDottyVersion
+val scalaVersions = "2.12.20" :: "2.13.16" :: "3.3.6" :: communityBuildDottyVersion
 
 val scalaReflectVersion = "1.1.3"
 

--- a/readme.md
+++ b/readme.md
@@ -660,19 +660,19 @@ Eventually and Continually
 
 ```scala
 val x = Seq(12)
-eventually(x == Nil)
+assertEventually(x == Nil)
 
-// utest.AssertionError: eventually(x == Nil)
+// utest.AssertionError: assertEventually(x == Nil)
 // x: Seq[Int] = List(12)
 ```
 
 In addition to a macro-powered `assert`, uTest also provides macro-powered
-versions of `eventually` and `continually`. These are used to test asynchronous
+versions of `assertEventually` and `assertContinually`. These are used to test asynchronous
 concurrent operations:
 
-- `eventually(tests: Boolean*)`: ensure that the boolean values of `tests` all
+- `assertEventually(tests: Boolean*)`: ensure that the boolean values of `tests` all
   become true at least once within a certain period of time.
-- `continually(tests: Boolean*)`: ensure that the boolean values of `tests` all
+- `assertContinually(tests: Boolean*)`: ensure that the boolean values of `tests` all
   remain true and never become false within a certain period of time.
 
 These are implemented via a retry-loop, with a default retry interval of 0.1
@@ -691,7 +691,7 @@ Together, these two operations allow you to easily test asynchronous operations.
 You can use them to help verify Liveness properties (that condition must
 eventually be met) and Safety properties (that a condition is never met)
 
-As with `assert`, `eventually` and `continually` add debugging information to
+As with `assert`, `assertEventually` and `assertContinually` add debugging information to
 the error messages if they fail.
 
 Assert Match
@@ -716,39 +716,39 @@ Compile Error
 -------------
 
 ```scala
-compileError("true * false")
+assertCompileError("true * false")
 // CompileError.Type("value * is not a member of Boolean")
 
-compileError("(}")
+assertCompileError("(}")
 // CompileError.Parse("')' expected but '}' found.")
 ```
 
-`compileError` is a macro that can be used to assert that a fragment of code
+`assertCompileError` is a macro that can be used to assert that a fragment of code
 (given as a literal String) fails to compile.
 
-- If the code compiles successfully, `compileError` will fail the compilation
+- If the code compiles successfully, `assertCompileError` will fail the compilation
   run with a message.
-- If the code fails to compile, `compileError` will return an instance of
+- If the code fails to compile, `assertCompileError` will return an instance of
   `CompileError`, one of `CompileError.Type(pos: String, msgs: String*)` or
   `CompileError.Parse(pos: String, msgs: String*)` to represent typechecker
   errors or parser errors
 
-In general, `compileError` works similarly to `assertThrows`, except it does its
+In general, `assertCompileError` works similarly to `assertThrows`, except it does its
 checks (that a snippet of code fails) and errors (if it doesn't fail) at
 compile-time rather than run-time. If the code fails as expected, the failure
 message is propagated to runtime in the form of a `CompileError` object. You can
 then do whatever additional checks you want on the failure message, such as
 verifying that the failure message contains some string you expect to be there.
 
-The `compileError` macro compiles the given string in the local scope and
+The `assertCompileError` macro compiles the given string in the local scope and
 context. This means that you can refer to variables in the enclosing scope, i.e.
 the following example will fail to compile because the variable `x` exists.
 
 ```scala
 val x = 0
 
-compileError("x + x"),
-// [error] compileError check failed to have a compilation error
+assertCompileError("x + x"),
+// [error] assertCompileError check failed to have a compilation error
 ```
 
 The returned `CompileError` object also has a handy `.check` method, which takes
@@ -757,9 +757,9 @@ zero-or-more messages which are expected to be part of the final error message.
 This is used as follows:
 
 ```scala
-compileError("true * false").check(
+assertCompileError("true * false").check(
   """
-compileError("true * false").check(
+assertCompileError("true * false").check(
                    ^
   """,
   "value * is not a member of Boolean"
@@ -768,7 +768,7 @@ compileError("true * false").check(
 
 Note that the position-string needs to exactly match the line of code the
 compile-error occured on. This includes any whitespace on the left, as well as
-any unrelated code or comments sharing the same line as the `compileError`
+any unrelated code or comments sharing the same line as the `assertCompileError`
 expression.
 
 Test Utilities

--- a/utest/src-2/utest/asserts/Asserts.scala
+++ b/utest/src-2/utest/asserts/Asserts.scala
@@ -18,7 +18,7 @@ import scala.language.experimental.macros
  * message for boolean expression assertion.
  */
 trait AssertsCompanionVersionSpecific {
-  def compileError(c: Context)(expr: c.Expr[String]): c.Expr[CompileError] = {
+  def assertCompileError(c: Context)(expr: c.Expr[String]): c.Expr[CompileError] = {
     import c.universe._
     val macrocompat = new MacroCompat(c)
     import macrocompat._
@@ -73,7 +73,7 @@ trait AssertsCompanionVersionSpecific {
             case None =>
               c.abort(
                 c.enclosingPosition,
-                "compileError check failed to have a compilation error"
+                "assertCompileError check failed to have a compilation error"
               )
           }
 
@@ -89,7 +89,7 @@ trait AssertsCompanionVersionSpecific {
       case e =>
         c.abort(
           expr.tree.pos,
-          s"You can only have literal strings in compileError, not ${expr.tree}"
+          s"You can only have literal strings in assertCompileError, not ${expr.tree}"
         )
     }
   }
@@ -132,7 +132,7 @@ trait AssertsVersionSpecific {
     * [[utest.CompileError]] containing the message of the failure. If the expression
     * compile successfully, this macro itself will raise a compilation error.
     */
-  def compileError(expr: String): CompileError = macro Asserts.compileError
+  def assertCompileError(expr: String): CompileError = macro Asserts.assertCompileError
 
   /**
    * Forwarder for `Predef.assert`, for when you want to explicitly write the
@@ -155,12 +155,12 @@ trait AssertsVersionSpecific {
     * Checks that one or more expressions all become true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  def eventually(expr: Boolean): Unit = macro Parallel.eventuallyProxy
+  def assertEventually(expr: Boolean): Unit = macro Parallel.eventuallyProxy
   /**
     * Checks that one or more expressions all remain true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  def continually(expr: Boolean): Unit = macro Parallel.continuallyProxy
+  def assertContinually(expr: Boolean): Unit = macro Parallel.continuallyProxy
 
   /**
     * Asserts that the given value matches the PartialFunction. Useful for using

--- a/utest/src-3/utest/asserts/Asserts.scala
+++ b/utest/src-3/utest/asserts/Asserts.scala
@@ -44,7 +44,7 @@ trait AssertsCompanionVersionSpecific {
       err.kind match
         case ErrorKind.Parser => CompileError.Parse(posStr, err.message)
         case ErrorKind.Typer => CompileError.Type(posStr, err.message)
-    }.getOrElse(Util.assertError(s"compileError check failed to have a compilation error when compiling\n$snippet", Nil))
+    }.getOrElse(Util.assertError(s"assertCompileError check failed to have a compilation error when compiling\n$snippet", Nil))
 }
 
 
@@ -56,7 +56,7 @@ trait AssertsVersionSpecific {
     * [[utest.CompileError]] containing the message of the failure. If the expression
     * compile successfully, this macro itself will raise a compilation error.
     */
-  transparent inline def compileError(inline expr: String): CompileError = compileErrorImpl(typeCheckErrors(expr), expr)
+  transparent inline def assertCompileError(inline expr: String): CompileError = compileErrorImpl(typeCheckErrors(expr), expr)
 
   /**
    * Checks that the expression is true; otherwise raises an
@@ -80,13 +80,13 @@ trait AssertsVersionSpecific {
     * Checks that one or more expressions all become true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  inline def eventually(inline expr: Boolean)(using ri: => RetryInterval, rm: => RetryMax): Unit =
+  inline def assertEventually(inline expr: Boolean)(using ri: => RetryInterval, rm: => RetryMax): Unit =
     ${Parallel.eventuallyProxy('expr, 'ri, 'rm)}
   /**
     * Checks that one or more expressions all remain true within a certain
     * period of time. Polls at a regular interval to check this.
     */
-  inline def continually(inline expr: Boolean)(using ri: => RetryInterval, rm: => RetryMax): Unit =
+  inline def assertContinually(inline expr: Boolean)(using ri: => RetryInterval, rm: => RetryMax): Unit =
     ${Parallel.continuallyProxy('expr, 'ri, 'rm)}
 
   /**

--- a/utest/src/utest/Errors.scala
+++ b/utest/src/utest/Errors.scala
@@ -88,7 +88,7 @@ object TestValue {
 
 /**
  * Simplified versions of the errors thrown during compilation, for use with the
- * [[utest.asserts.Asserts.compileError]] macro. Contains only a single message and no position since
+ * [[utest.asserts.Asserts.assertCompileError]] macro. Contains only a single message and no position since
  * things compiled using macros don't really have source positions.
  */
 trait CompileError extends CompileErrorVersionSpecific {

--- a/utest/src/utest/asserts/Parallel.scala
+++ b/utest/src/utest/asserts/Parallel.scala
@@ -7,12 +7,12 @@ import scala.util.{Failure, Success, Try}
 
 /**
  * Used to specify a retry-interval for the `eventually` and
- * `continually` asserts.
+ * `assertContinually` asserts.
  */
 case class RetryInterval(d: FiniteDuration)
 /**
  * Used to specify a maximum retry duration for the `eventually`
- * and `continually` asserts.
+ * and `assertContinually` asserts.
  */
 case class RetryMax(d: FiniteDuration)
 
@@ -54,7 +54,7 @@ object Parallel extends ParallelVersionSpecific {
       die match{
         case Some((logged, src)) =>
           Util.assertError(
-            "continually " + src,
+            "assertContinually " + src,
             logged
           )
         case None if Deadline.now < start + max.d =>

--- a/utest/test/src-2/test/utest/AssertsTestsVersionSpecific.scala
+++ b/utest/test/src-2/test/utest/AssertsTestsVersionSpecific.scala
@@ -5,66 +5,66 @@ object AssertsTestsVersionSpecific extends utest.TestSuite{
 
   implicit val colors = shaded.pprint.TPrintColors.Colors
   def tests = Tests{
-    test("compileError"){
+    test("assertCompileError"){
       test("failure"){
-        // Use compileError to check itself to verify that when it
+        // Use assertCompileError to check itself to verify that when it
         // doesn't throw an error, it actually does (super meta!)
         test("1") {
-          compileError("""
-              compileError("1 + 1").check(
+          assertCompileError("""
+              assertCompileError("1 + 1").check(
                 ""
               )
             """).check(
             """
-              compileError("1 + 1").check(
+              assertCompileError("1 + 1").check(
                           ^
             """,
-            "compileError check failed to have a compilation error"
+            "assertCompileError check failed to have a compilation error"
           )
         }
         test("2") {
-          compileError("""
+          assertCompileError("""
               val x = 0
-              compileError("x + x").check(
+              assertCompileError("x + x").check(
               ""
             )
             """).check(
             """
-              compileError("x + x").check(
+              assertCompileError("x + x").check(
                           ^
             """,
-            "compileError check failed to have a compilation error"
+            "assertCompileError check failed to have a compilation error"
           )
         }
         test("3") {
-          compileError("""
-              compileError("1" * 2).check(
+          assertCompileError("""
+              assertCompileError("1" * 2).check(
                 ""
               )
           """).check(
             """
-              compileError("1" * 2).check(
+              assertCompileError("1" * 2).check(
                                ^
             """,
-            "You can only have literal strings in compileError"
+            "You can only have literal strings in assertCompileError"
           )
         }
 
       }
       test("compileTimeOnly"){
         // Make sure that when the body contains a `@compileTimeOnly`, it
-        // gets counted as a valid compile error and `compileError` passes
-        compileError("compileTimeOnlyVal").check(
+        // gets counted as a valid compile error and `assertCompileError` passes
+        assertCompileError("compileTimeOnlyVal").check(
           """
-        compileError("compileTimeOnlyVal").check(
+        assertCompileError("compileTimeOnlyVal").check(
                       ^
           """,
           "compileTimeOnlyVal should be a compile error if used!"
         )
 
-        compileError("{ println(1 + 1); class F{ def foo() = { println(compileTimeOnlyVal) } } }").check(
+        assertCompileError("{ println(1 + 1); class F{ def foo() = { println(compileTimeOnlyVal) } } }").check(
           """
-        compileError("{ println(1 + 1); class F{ def foo() = { println(compileTimeOnlyVal) } } }").check(
+        assertCompileError("{ println(1 + 1); class F{ def foo() = { println(compileTimeOnlyVal) } } }").check(
                                                                        ^
           """,
           "compileTimeOnlyVal should be a compile error if used!"

--- a/utest/test/src-3/test/utest/AssertsTestsVersionSpecific.scala
+++ b/utest/test/src-3/test/utest/AssertsTestsVersionSpecific.scala
@@ -5,13 +5,13 @@ object AssertsTestsVersionSpecific extends utest.TestSuite{
 
 
   def tests = Tests{
-    test("compileError"){
+    test("assertCompileError"){
       test("failure"){
         test - {
-          try compileError("1 + 1").check("")
+          try assertCompileError("1 + 1").check("")
           catch { case e: utest.AssertionError =>
             assert(e.getMessage ==
-              """compileError check failed to have a compilation error when compiling
+              """assertCompileError check failed to have a compilation error when compiling
                 |1 + 1""".stripMargin)
           }
         }
@@ -19,20 +19,20 @@ object AssertsTestsVersionSpecific extends utest.TestSuite{
         test - {
           try {
             val x = 0
-            compileError("x + x").check("")
+            assertCompileError("x + x").check("")
           }
           catch { case e: utest.AssertionError =>
             assert(e.getMessage ==
-              """compileError check failed to have a compilation error when compiling
+              """assertCompileError check failed to have a compilation error when compiling
                 |x + x""".stripMargin)
           }
         }
 
-        test - compileError(
-            """compileError("1" * 2).check("")"""
-          ).check("""compileError("1" * 2).check("")
+        test - assertCompileError(
+            """assertCompileError("1" * 2).check("")"""
+          ).check("""assertCompileError("1" * 2).check("")
                       |             ^""".stripMargin,
-              """argument to compileError must be a statically known String but was: augmentString("1").*(2)"""
+              """argument to assertCompileError must be a statically known String but was: augmentString("1").*(2)"""
           )
       }
     }

--- a/utest/test/src-jvm/test/utest/Parallel.scala
+++ b/utest/test/src-jvm/test/utest/Parallel.scala
@@ -50,12 +50,12 @@ object Parallel extends TestSuite{
 //      "Speedup: " + speedup
 //    }
 
-    "eventually"-{
+    "assertEventually"-{
       "failure"-{
         val x = Seq(12)
         val y = 1
         val error = assertThrows[AssertionError]{
-          eventually(x == Nil && y == 1)
+          assertEventually(x == Nil && y == 1)
         }
 
         val expected = Seq(
@@ -81,7 +81,7 @@ object Parallel extends TestSuite{
       "success"-{
         val i = Counter()
 
-        eventually(
+        assertEventually(
           i() > 5
         )
 
@@ -94,7 +94,7 @@ object Parallel extends TestSuite{
         val i = Counter()
 
         assertThrows[AssertionError]{
-          eventually{
+          assertEventually{
             i() > 5
           }
         }
@@ -107,19 +107,19 @@ object Parallel extends TestSuite{
         val i = Counter()
 
         assertThrows[AssertionError]{
-          eventually{
+          assertEventually{
             i() > 5
           }
         }
       }
     }
 
-    "continually"-{
+    "assertContinually"-{
       "failure"-{
 
         val i = Counter()
         val error = assertThrows[AssertionError]{
-          continually(
+          assertContinually(
             i() < 4
           )
         }
@@ -133,7 +133,7 @@ object Parallel extends TestSuite{
         val x = Seq(12)
         val y = 1
 
-        continually(x == Seq(12) && y == 1)
+        assertContinually(x == Seq(12) && y == 1)
       }
     }
   }

--- a/utest/test/src/test/utest/AssertsTests.scala
+++ b/utest/test/src/test/utest/AssertsTests.scala
@@ -311,33 +311,33 @@ object AssertsTests extends utest.TestSuite{
         ()
       }
     }
-    test("compileError"){
+    test("assertCompileError"){
       test("success"){
         // Make sure that on successfully catching a compilation
         // error, the error it reports is in the correct place for
         // a variety of inputs
         val qq = "\"" * 3
-        test - compileError("1 + abc").check(
+        test - assertCompileError("1 + abc").check(
           if (BuildInfo.scalaVersion.startsWith("3.")) """|1 + abc
                           |    ^  """.stripMargin
           else """
-        test - compileError("1 + abc").check(
+        test - assertCompileError("1 + abc").check(
                                  ^
           """,
           if (BuildInfo.scalaVersion.startsWith("3.")) "Not found: abc"
           else "not found: value abc"
         )
-        test - compileError(""" 1 + abc""").check(
+        test - assertCompileError(""" 1 + abc""").check(
           if (BuildInfo.scalaVersion.startsWith("3.")) """ 1 + abc
                          |     ^""".stripMargin
           else s"""
-        test - compileError($qq 1 + abc$qq).check(
+        test - assertCompileError($qq 1 + abc$qq).check(
                                     ^
           """,
           if (BuildInfo.scalaVersion.startsWith("3.")) "Not found: abc"
           else "not found: value abc"
         )
-        test - compileError("""
+        test - assertCompileError("""
             1 + abc
           """).check(
           if (BuildInfo.scalaVersion.startsWith("3.")) """
@@ -350,7 +350,7 @@ object AssertsTests extends utest.TestSuite{
           if (BuildInfo.scalaVersion.startsWith("3.")) "Not found: abc"
           else "not found: value abc"
         )
-        test - compileError("""
+        test - assertCompileError("""
 
 
 
@@ -370,27 +370,27 @@ object AssertsTests extends utest.TestSuite{
           if (BuildInfo.scalaVersion.startsWith("3.")) "Not found: abc"
           else "not found: value abc"
         )
-        test - compileError("true * false").check(
+        test - assertCompileError("true * false").check(
           if (BuildInfo.scalaVersion.startsWith("3.")) """true * false
                          |     ^""".stripMargin
           else """
-        test - compileError("true * false").check(
+        test - assertCompileError("true * false").check(
                                   ^
           """,
           "value * is not a member of Boolean"
         )
         // need to work around inability to use """ in string
 
-        test - compileError(""" true * false""").check(
+        test - assertCompileError(""" true * false""").check(
           if (BuildInfo.scalaVersion.startsWith("3.")) """ true * false
                          |      ^""".stripMargin
           else s"""
-        test - compileError($qq true * false$qq).check(
+        test - assertCompileError($qq true * false$qq).check(
                                      ^
           """,
           "value * is not a member of Boolean"
         )
-        test - compileError("ab ( cd }").check(
+        test - assertCompileError("ab ( cd }").check(
           """""",
           if (BuildInfo.scalaVersion.startsWith("3.")) "')' expected, but '}' found"
           else "')' expected but '}' found."


### PR DESCRIPTION
This helps improve the consistency of the `assert*` naming convention