### PR TITLE
Fix missing last test when return type is string

### DIFF
--- a/utest/src-2/utest/Tests.scala
+++ b/utest/src-2/utest/Tests.scala
@@ -57,6 +57,9 @@ object TestsVersionSpecific {
 
         case q"""utest.this.`package`.test.apply($body)""" => (None, body)
         case q"""utest.`package`.test.apply($body)""" => (None, body)
+
+        case q"""{utest.this.`package`.test.apply($body); ()}""" => (None, body)
+        case q"""{utest.`package`.test.apply($body); ()}""" => (None, body)
       }
 
       def recurse(t: c.Tree, path: Seq[String]): (c.Tree, collection.Seq[c.Tree]) = {

--- a/utest/test/src/test/utest/DisablePrintTests.scala
+++ b/utest/test/src/test/utest/DisablePrintTests.scala
@@ -15,3 +15,4 @@ object DisablePrintTests extends utest.TestSuite{
   }
 }
 
+

--- a/utest/test/src/test/utest/HelloTests.scala
+++ b/utest/test/src/test/utest/HelloTests.scala
@@ -1,0 +1,22 @@
+package test.utest
+
+import utest._
+object HelloTests extends TestSuite {
+  val tests = Tests {
+    test {  1  }
+
+    test { "a" }
+
+    test { throw new Exception("foo") }
+
+    test {  2  }
+
+    test { "b" }
+
+
+  }
+  shaded.pprint.log(tests)
+}
+
+
+

--- a/utest/test/src/test/utest/TestDiscoveryTests.scala
+++ b/utest/test/src/test/utest/TestDiscoveryTests.scala
@@ -1,0 +1,33 @@
+
+package test.utest
+
+import utest._
+
+object TestDiscoveryTests extends utest.TestSuite{
+
+  val testsTopLevelStrings = Tests {
+    test {  1  }
+    test { "a" }
+    test { throw new Exception("foo") }
+    test {  2  }
+    test { "b" }
+  }
+
+  val testsAnon = Tests {
+    test("utest bug v2") {
+      test { // name removed
+        1 ==> 1
+        "one"
+      }
+      test { // name removed
+        2 ==> 2
+        "two"
+      }
+    }
+  }
+
+  val tests = Tests{
+    test - assert(testsTopLevelStrings.nameTree.children.length == 5)
+    test - assert(testsAnon.nameTree.children(0).children.length == 2)
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/com-lihaoyi/utest/issues/252

The problem is that when the last `test{}` block has the return type of `String`, it picks the overload returning `utest.Apply`, and then wraps it in a block to insert a `()` after it. The fix is to identify this pattern and unwind it so it is treated as a normal statement

Also added some tests for this and https://github.com/com-lihaoyi/utest/pull/390